### PR TITLE
Optimize API performance with NTP time and caching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,4 +45,5 @@ typing-inspection==0.4.1
 typing_extensions==4.14.0
 url-normalize==2.2.1
 urllib3==2.4.0
-uvicorn==0.34.3 
+uvicorn==0.34.3
+cachetools==6.1.0


### PR DESCRIPTION
- Replaced `get_time_from_google` with `get_ntp_time` for more efficient current time retrieval in `/api/v4/now`.
- Implemented LRU caching using `cachetools` for various endpoints to reduce latency on repeated requests and decrease server load.
  - Added `geonames_cache` for `birth-data` endpoint.
  - Added `chart_cache` for endpoints generating SVG charts (`birth-chart`, `synastry-chart`, `transit-chart`, `composite-chart`).
  - Added `aspect_data_cache` for endpoints returning astrological data/aspects (`transit-aspects-data`, `synastry-aspects-data`, `natal-aspects-data`, `relationship-score`, `composite-aspects-data`).
- Created a `make_cache_key` utility to generate consistent cache keys from request models.
- Added `cachetools` to `requirements.txt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved performance for several API endpoints through caching of frequently requested data.
- **Chores**
	- Added a new dependency to support caching functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->